### PR TITLE
Refactor tower repository and add tower service tests

### DIFF
--- a/backend/0.2 Infrastructure/Repository/TowerRepository.cs
+++ b/backend/0.2 Infrastructure/Repository/TowerRepository.cs
@@ -1,8 +1,5 @@
-﻿using Application.Schemas.Requests;
-using Domain.Common.Models;
-using Domain.Entities;
+﻿using Domain.Entities;
 using Domain.Repository;
-using Application.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Repository
@@ -30,26 +27,6 @@ namespace Infrastructure.Repository
             return await _context.Towers
                 .Include(t => t.Apartments)
                 .FirstOrDefaultAsync(t => t.Id == id);
-        }
-
-        public async Task<PagedResult<Tower>> GetPublicTowerListAsync(TowerFilterParams filterParams)
-        {
-            var query = _context.Towers.AsNoTracking()
-                .ApplyFilters(filterParams)
-                .ApplySorting(filterParams.SortBy, filterParams.SortOrder);
-
-            var totalRecords = await query.CountAsync();
-
-            var data = await query
-                .Skip((filterParams.PageNumber - 1) * filterParams.PageSize)
-                .Take(filterParams.PageSize)
-                .ToListAsync();
-
-            return new PagedResult<Tower>
-            {
-                Items = data,
-                TotalRecords = totalRecords
-            };
         }
 
         public async Task<Tower?> GetByNameAsync(string name)

--- a/backend/0.4 Domain/Repository/ITowerRepository.cs
+++ b/backend/0.4 Domain/Repository/ITowerRepository.cs
@@ -1,5 +1,4 @@
-﻿using Domain.Common.Models;
-using Domain.Entities;
+﻿using Domain.Entities;
 
 namespace Domain.Repository
 {
@@ -11,6 +10,5 @@ namespace Domain.Repository
         Task<Tower?> GetByIdAsync(int id);
         Task<Tower?> GetByNameAsync(string name);
         Task UpdateAsync(Tower tower);
-        Task<PagedResult<Tower>> GetPublicTowerListAsync(TowerFilterParams filterParams);
     }
 }

--- a/backend/0.5 Tests/Application.Tests.csproj
+++ b/backend/0.5 Tests/Application.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\0.3 Application\Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/0.5 Tests/TowerServiceTests.cs
+++ b/backend/0.5 Tests/TowerServiceTests.cs
@@ -1,0 +1,90 @@
+using AutoMapper;
+using Application.Schemas.Profiles;
+using Application.Schemas.Requests;
+using Application.Services.Implementations;
+using Domain.Entities;
+using Domain.Repository;
+using Moq;
+using Xunit;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Tests
+{
+    public class TowerServiceTests
+    {
+        private readonly IMapper _mapper;
+
+        public TowerServiceTests()
+        {
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<TowerProfile>());
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public async Task GetPublicTowerListAsync_FiltersAndPaginates()
+        {
+            // Arrange
+            var towers = new List<Tower>
+            {
+                new Tower { Id = 1, Name = "Alpha" },
+                new Tower { Id = 2, Name = "Beta" },
+                new Tower { Id = 3, Name = "Alpine" }
+            }.AsQueryable();
+
+            var repoMock = new Mock<ITowerRepository>();
+            repoMock.Setup(r => r.GetAsQueryable()).Returns(towers);
+            var service = new TowerService(repoMock.Object, _mapper);
+
+            var filter = new TowerFilterParams
+            {
+                Name = "Al",
+                PageNumber = 1,
+                PageSize = 1,
+                SortBy = "Name",
+                SortOrder = "asc"
+            };
+
+            // Act
+            var result = await service.GetPublicTowerListAsync(filter);
+
+            // Assert
+            Assert.Equal(2, result.TotalRecords);
+            Assert.Single(result.Data);
+            Assert.Equal("Alpha", result.Data.First().Name);
+        }
+
+        [Fact]
+        public async Task GetPublicTowerListAsync_ReturnsSecondPage()
+        {
+            // Arrange
+            var towers = new List<Tower>
+            {
+                new Tower { Id = 1, Name = "Alpha" },
+                new Tower { Id = 2, Name = "Beta" },
+                new Tower { Id = 3, Name = "Alpine" }
+            }.AsQueryable();
+
+            var repoMock = new Mock<ITowerRepository>();
+            repoMock.Setup(r => r.GetAsQueryable()).Returns(towers);
+            var service = new TowerService(repoMock.Object, _mapper);
+
+            var filter = new TowerFilterParams
+            {
+                Name = "Al",
+                PageNumber = 2,
+                PageSize = 1,
+                SortBy = "Name",
+                SortOrder = "asc"
+            };
+
+            // Act
+            var result = await service.GetPublicTowerListAsync(filter);
+
+            // Assert
+            Assert.Single(result.Data);
+            Assert.Equal("Alpine", result.Data.First().Name);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Simplify `ITowerRepository` to expose only CRUD operations and base queries
- Remove filtering logic and application-layer dependencies from `TowerRepository`
- Add unit tests ensuring `TowerService` performs filtering and pagination

## Testing
- `dotnet test backend/'0.5 Tests'/Application.Tests.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6893d961806483288eef2b8de16e568a