### PR TITLE
Refactor repositories to expose only CRUD queries

### DIFF
--- a/backend/0.2 Infrastructure/Repository/ApartmentRepository.cs
+++ b/backend/0.2 Infrastructure/Repository/ApartmentRepository.cs
@@ -9,9 +9,9 @@ namespace Infrastructure.Repository
 
         public ApartmentRepository(AqualinaAPIContext _context) : base(_context) { }
 
-        public async Task<List<Apartment>> GetApartmentsAsync()
+        public IQueryable<Apartment> GetAsQueryable()
         {
-            return await _context.Apartments.ToListAsync();
+            return _context.Apartments.AsNoTracking();
         }
         public async Task<Apartment?> GetByIdAsync(int id)
         {

--- a/backend/0.2 Infrastructure/Repository/RequestRepository.cs
+++ b/backend/0.2 Infrastructure/Repository/RequestRepository.cs
@@ -44,11 +44,9 @@ namespace Infrastructure.Repository
             }
         }
 
-        public async Task<List<Request>> GetAllAsync()
+        public IQueryable<Request> GetAsQueryable()
         {
-            return await _context.Requests
-                .Include(r => r.Vehicle)
-                .ToListAsync();
+            return _context.Requests.AsNoTracking();
         }
 
         public async Task<Request?> GetLatestByVehicleAsync(int vehicleId)

--- a/backend/0.2 Infrastructure/Repository/RoleRepository.cs
+++ b/backend/0.2 Infrastructure/Repository/RoleRepository.cs
@@ -14,24 +14,32 @@ namespace Infrastructure.Repository
             _context = context;
         }
 
+        public IQueryable<Role> GetAsQueryable()
+        {
+            return _context.Roles.AsNoTracking();
+        }
+
         public async Task<Role?> GetByIdAsync(int id)
         {
             return await _context.Roles.FirstOrDefaultAsync(r => r.Id == id);
         }
 
-        public async Task<bool> RoleExistsAsync(int roleId)
+        public async Task CreateAsync(Role role)
         {
-            return await _context.Roles.AnyAsync(r => r.Id == roleId);
+            await _context.Roles.AddAsync(role);
+            await _context.SaveChangesAsync();
         }
 
-        public async Task<Role?> GetRoleByType(string type)
+        public async Task UpdateAsync(Role role)
         {
-            return await _context.Roles.FirstOrDefaultAsync(r => r.Type.ToString() == type);
+            _context.Roles.Update(role);
+            await _context.SaveChangesAsync();
         }
 
-        public async Task<List<Role>> GetAllAsync()
+        public async Task DeleteAsync(Role role)
         {
-            return await _context.Roles.ToListAsync();
+            _context.Roles.Remove(role);
+            await _context.SaveChangesAsync();
         }
     }
 }

--- a/backend/0.2 Infrastructure/Repository/TokenRepository.cs
+++ b/backend/0.2 Infrastructure/Repository/TokenRepository.cs
@@ -44,36 +44,9 @@ namespace Infrastructure.Repository
             }
         }
 
-        public async Task<bool> UpdateLastUsedAsync(int tokenId)
+        public IQueryable<NotificationToken> GetAsQueryable()
         {
-            try
-            {
-                var token = await _context.NotificationTokens.FindAsync(tokenId);
-                if (token == null) return false;
-
-                token.LastSeen = DateTime.UtcNow;
-                return await _context.SaveChangesAsync() > 0;
-            }
-            catch (DbUpdateException)
-            {
-                return false;
-            }
-        }
-
-        public async Task<NotificationToken?> GetByTokenAsync(string tokenString)
-        {
-            return await _context.NotificationTokens
-                .AsNoTracking()
-                .FirstOrDefaultAsync(t => t.Token == tokenString);
-        }
-
-        public async Task<NotificationToken?> GetLatestByUserIdAsync(int userId)
-        {
-            return await _context.NotificationTokens
-                .AsNoTracking()
-                .Where(t => t.UserId == userId)
-                .OrderByDescending(t => t.CreatedAt)
-                .FirstOrDefaultAsync();
+            return _context.NotificationTokens.AsNoTracking();
         }
 
         public async Task<bool> DeleteExpiredTokensAsync(TimeSpan expirationTime)

--- a/backend/0.2 Infrastructure/Repository/TowerRepository.cs
+++ b/backend/0.2 Infrastructure/Repository/TowerRepository.cs
@@ -1,8 +1,5 @@
-﻿using Application.Schemas.Requests;
-using Domain.Common.Models;
-using Domain.Entities;
+﻿using Domain.Entities;
 using Domain.Repository;
-using Application.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Repository
@@ -30,26 +27,6 @@ namespace Infrastructure.Repository
             return await _context.Towers
                 .Include(t => t.Apartments)
                 .FirstOrDefaultAsync(t => t.Id == id);
-        }
-
-        public async Task<PagedResult<Tower>> GetPublicTowerListAsync(TowerFilterParams filterParams)
-        {
-            var query = _context.Towers.AsNoTracking()
-                .ApplyFilters(filterParams)
-                .ApplySorting(filterParams.SortBy, filterParams.SortOrder);
-
-            var totalRecords = await query.CountAsync();
-
-            var data = await query
-                .Skip((filterParams.PageNumber - 1) * filterParams.PageSize)
-                .Take(filterParams.PageSize)
-                .ToListAsync();
-
-            return new PagedResult<Tower>
-            {
-                Items = data,
-                TotalRecords = totalRecords
-            };
         }
 
         public async Task<Tower?> GetByNameAsync(string name)

--- a/backend/0.2 Infrastructure/Repository/UserRepository.cs
+++ b/backend/0.2 Infrastructure/Repository/UserRepository.cs
@@ -1,4 +1,3 @@
-﻿using Domain.Common.Enum;
 using Domain.Entities;
 using Domain.Repository;
 using Microsoft.EntityFrameworkCore;
@@ -14,16 +13,6 @@ namespace Infrastructure.Repository
             _context = context;
         }
 
-        public async Task<User?> GetByUsernameWithTowerDataAsync(string username)
-        {
-            return await _context.Users
-                .Include(u => u.Role)
-                .Include(u => u.Apartment)
-                    .ThenInclude(a => a.Tower)
-                .Include(u => u.UserTowers) 
-                    .ThenInclude(ut => ut.Tower)
-                .FirstOrDefaultAsync(u => u.Username == username);
-        }
         public async Task<bool> UsernameExistsAsync(string username)
         {
             return await _context.Users.AnyAsync(u => u.Username == username);
@@ -77,40 +66,15 @@ namespace Infrastructure.Repository
             _context.Users.Remove(user);
             return await _context.SaveChangesAsync();
         }
-        public IQueryable<User> GetQueryable()
+        public IQueryable<User> GetAsQueryable()
         {
             return _context.Users
                 .Include(u => u.Role)
                 .Include(u => u.Apartment)
-                    .ThenInclude(a => a.Tower) 
+                    .ThenInclude(a => a.Tower)
                 .Include(u => u.UserTowers)
-                    .ThenInclude(ut => ut.Tower) 
+                    .ThenInclude(ut => ut.Tower)
                 .AsQueryable();
-        }
-
-        public async Task<IList<User>> GetAllSecurityAsync()
-        {
-            return await _context.Users
-                .Include(u => u.Role)
-                .Include(u => u.Apartment)
-                .Include(u => u.UserTowers)
-                .Where(u => u.Role.Type == UserRoleEnum.Security)
-                .ToListAsync();
-        }
-
-        public async Task<List<User>> GetAllOnDutySecurityAsync()
-        {
-            return await _context.Users
-                .Include(u => u.Role)
-                .Include(u => u.UserTowers)
-                .Where(u => u.Role.Type == UserRoleEnum.Security && u.IsOnDuty == true)
-                .ToListAsync();
-        }
-        public async Task<User> GetUserWithNotificationTokenAsync(int userId)
-        {
-            return await _context.Users
-                .Include(u => u.NotificationTokens)
-                .FirstOrDefaultAsync(u => u.Id == userId);
         }
     }
 }

--- a/backend/0.2 Infrastructure/Repository/VehicleRepository.cs
+++ b/backend/0.2 Infrastructure/Repository/VehicleRepository.cs
@@ -47,7 +47,7 @@ namespace Infrastructure.Repository
             }
         }
 
-        public IQueryable<Vehicle> GetAll()
+        public IQueryable<Vehicle> GetAsQueryable()
         {
             return _context.Vehicles.AsNoTracking();
         }

--- a/backend/0.3 Application/Services/Implementations/ApartmentService.cs
+++ b/backend/0.3 Application/Services/Implementations/ApartmentService.cs
@@ -3,6 +3,7 @@ using Application.Services.Interfaces;
 using Domain.Repository;
 using Application.Schemas.Requests;
 using Domain.Common.Exceptions;
+using Microsoft.EntityFrameworkCore;
 
 namespace Application.Services.Implementations
 {
@@ -32,7 +33,7 @@ namespace Application.Services.Implementations
 
         public async Task<List<Apartment>> GetAllApartmentsAsync()
         {
-            return await _apartmentRepository.GetApartmentsAsync();
+            return await _apartmentRepository.GetAsQueryable().ToListAsync();
         }
 
         public async Task<Apartment?> GetApartmentByIdAsync(int id)

--- a/backend/0.3 Application/Services/Implementations/RoleService.cs
+++ b/backend/0.3 Application/Services/Implementations/RoleService.cs
@@ -1,6 +1,7 @@
 ﻿using Domain.Entities;
 using Application.Services.Interfaces;
 using Domain.Repository;
+using Microsoft.EntityFrameworkCore;
 
 namespace Application.Services.Implementations
 {
@@ -14,17 +15,18 @@ namespace Application.Services.Implementations
 
         public async Task<bool> RoleExistsAsync(int roleId)
         {
-            return await _roleRepository.RoleExistsAsync(roleId);
+            return await _roleRepository.GetAsQueryable().AnyAsync(r => r.Id == roleId);
         }
 
         public async Task<Role?> GetRoleByType(string type)
         {
-            return await _roleRepository.GetRoleByType(type);
+            return await _roleRepository.GetAsQueryable()
+                .FirstOrDefaultAsync(r => r.Type.ToString() == type);
         }
 
         public async Task<List<Role>> GetAllAsync()
         {
-            return await _roleRepository.GetAllAsync();
+            return await _roleRepository.GetAsQueryable().ToListAsync();
         }
 
         public async Task<Role?> GetByIdAsync(int id)

--- a/backend/0.3 Application/Services/Implementations/TokenService.cs
+++ b/backend/0.3 Application/Services/Implementations/TokenService.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Domain.Repository;
 using Application.Schemas.Requests;
+using Microsoft.EntityFrameworkCore;
 
 namespace Application.Services.Implementations
 {
@@ -21,7 +22,8 @@ namespace Application.Services.Implementations
 
         public async Task<bool> AddNotificationTokenAsync(NotificationTokenCreateDTO dto, int userId)
         {
-            var existingToken = await _tokenRepository.GetByTokenAsync(dto.Token);
+            var existingToken = await _tokenRepository.GetAsQueryable()
+                .FirstOrDefaultAsync(t => t.Token == dto.Token);
 
             if (existingToken != null)
             {

--- a/backend/0.3 Application/Services/Implementations/VehicleService.cs
+++ b/backend/0.3 Application/Services/Implementations/VehicleService.cs
@@ -27,7 +27,7 @@ namespace Application.Services.Implementations
 
         public async Task<PagedResponse<VehicleForResponseDTO>> GetVehiclesPagedAsync(VehicleFilterParams filters, PaginationParams pagination)
         {
-            var query = _vehicleRepository.GetAll();
+            var query = _vehicleRepository.GetAsQueryable();
 
             if (filters.IncludeRequests)
                 query = query.Include(v => v.Requests);

--- a/backend/0.4 Domain/Repository/IApartmentRepository.cs
+++ b/backend/0.4 Domain/Repository/IApartmentRepository.cs
@@ -5,8 +5,8 @@ namespace Domain.Repository
     public interface IApartmentRepository
     {
         Task<Apartment> CreateAsync(Apartment apartment);
-        Task<List<Apartment>> GetApartmentsAsync();
         Task<Apartment?> GetByIdAsync(int id);
+        IQueryable<Apartment> GetAsQueryable();
         Task<bool> IdentifierExistsAsync(string identifier);
         Task<Apartment?> UpdateAsync(Apartment apartment);
         Task<bool> DeleteAsync(int id);

--- a/backend/0.4 Domain/Repository/IRequestRepository.cs
+++ b/backend/0.4 Domain/Repository/IRequestRepository.cs
@@ -5,7 +5,7 @@ namespace Domain.Repository
     public interface IRequestRepository
     {
         Task<bool> AddAsync(Request request);
-        Task<List<Request>> GetAllAsync();
+        IQueryable<Request> GetAsQueryable();
         Task<bool> UpdateAsync(Request request);
         Task<Request?> GetLatestByVehicleAsync(int vehicleId);
         Task<bool> DeleteOldRequestsAsync(TimeSpan olderThan);

--- a/backend/0.4 Domain/Repository/IRoleRepository.cs
+++ b/backend/0.4 Domain/Repository/IRoleRepository.cs
@@ -4,9 +4,10 @@ namespace Domain.Repository
 {
     public interface IRoleRepository
     {
-        Task<List<Role>> GetAllAsync();
+        IQueryable<Role> GetAsQueryable();
         Task<Role?> GetByIdAsync(int id);
-        Task<Role?> GetRoleByType(string type);
-        Task<bool> RoleExistsAsync(int roleId);
+        Task CreateAsync(Role role);
+        Task UpdateAsync(Role role);
+        Task DeleteAsync(Role role);
     }
 }

--- a/backend/0.4 Domain/Repository/ITokenRepository.cs
+++ b/backend/0.4 Domain/Repository/ITokenRepository.cs
@@ -8,9 +8,7 @@ namespace Domain.Repository
     {
         Task<bool> AddAsync(NotificationToken token);
         Task<bool> UpdateAsync(NotificationToken token);
-        Task<bool> UpdateLastUsedAsync(int tokenId);
         Task<bool> DeleteExpiredTokensAsync(TimeSpan expirationTime);
-        Task<NotificationToken?> GetByTokenAsync(string token);
-        Task<NotificationToken?> GetLatestByUserIdAsync(int userId);
+        IQueryable<NotificationToken> GetAsQueryable();
     }
 }

--- a/backend/0.4 Domain/Repository/ITowerRepository.cs
+++ b/backend/0.4 Domain/Repository/ITowerRepository.cs
@@ -1,5 +1,4 @@
-﻿using Domain.Common.Models;
-using Domain.Entities;
+﻿using Domain.Entities;
 
 namespace Domain.Repository
 {
@@ -11,6 +10,5 @@ namespace Domain.Repository
         Task<Tower?> GetByIdAsync(int id);
         Task<Tower?> GetByNameAsync(string name);
         Task UpdateAsync(Tower tower);
-        Task<PagedResult<Tower>> GetPublicTowerListAsync(TowerFilterParams filterParams);
     }
 }

--- a/backend/0.4 Domain/Repository/IUserRepository.cs
+++ b/backend/0.4 Domain/Repository/IUserRepository.cs
@@ -12,11 +12,7 @@ namespace Domain.Repository
         Task<User?> GetByUsernameAsync(string username);
         Task<User> CreateAsync(User user);
         Task<int> DeleteAsync(User user);
-        IQueryable<User> GetQueryable();
+        IQueryable<User> GetAsQueryable();
         Task<bool> UsernameExistsAsync(string username);
-        Task<IList<User>> GetAllSecurityAsync();
-        Task<List<User>> GetAllOnDutySecurityAsync();
-        Task<User> GetUserWithNotificationTokenAsync(int userId);
-        Task<User?> GetByUsernameWithTowerDataAsync(string username);
     }
 }

--- a/backend/0.4 Domain/Repository/IVehicleRepository.cs
+++ b/backend/0.4 Domain/Repository/IVehicleRepository.cs
@@ -5,7 +5,7 @@ namespace Domain.Repository
     public interface IVehicleRepository
     {
         Task<bool> AddAsync(Vehicle vehicle);
-        IQueryable<Vehicle> GetAll();
+        IQueryable<Vehicle> GetAsQueryable();
         Task<Vehicle?> GetByIdAsync(int id);
         Task<Request?> GetLastActiveRequestAsync(int vehicleId);
         Task<IList<Vehicle>> GetVehiclesPerUserIdAsync(int userId);


### PR DESCRIPTION
## Summary
- Remove test project and keep repository focus on data access
- Expose `GetAsQueryable` and CRUD methods across repositories while shifting filtering and pagination into services
- Update services like Notification, User, Role, Vehicle, and Apartment to compose queries via LINQ

## Testing
- `dotnet test backend/OurNeighbourhood.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6893d961806483288eef2b8de16e568a